### PR TITLE
Difficulty-Specific Vocals Demo

### DIFF
--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -1665,6 +1665,7 @@ class PlayState extends MusicBeatState
 
 					if (SONG.needsVoices)
 						vocals.volume = 1;
+						vocals.fadeOut(0.2);
 
 					daNote.kill();
 					notes.remove(daNote, true);
@@ -2236,6 +2237,7 @@ class PlayState extends MusicBeatState
 
 			note.wasGoodHit = true;
 			vocals.volume = 1;
+			vocals.fadeOut(0.2);
 
 			if (!note.isSustainNote)
 			{


### PR DESCRIPTION
Each difficulty has different charts. Instead of redoing vocal tracks to match the charts, the in-game engine can selectively mute the vocals to match it to the chart. This provides backwards compatibility and mod compatibility. This is a demonstration, but it could see better implementation if the hard mode chart were always loaded, so note lengths could be adjusted.
Uses fadeOut() to asynchronously silence the vocal track after 0.2 seconds whenever a good hit is made by Boyfriend or the opponent (before the note is destroyed).
Known issues:
- fadeOut() quiets the track, making it hard to hear alongside the music. This is exacerbated if the chart does not perfectly align with the vocal track.
- Some notes that are very close in Hard mode can be heard on certain notes.
- Certain notes sound cut-off or held notes replace the fast inputs of Hard mode, so the representation is not perfect.